### PR TITLE
fix: Hide terminal cursor when process is not running

### DIFF
--- a/src/components/pixi/process/terminal.tsx
+++ b/src/components/pixi/process/terminal.tsx
@@ -29,6 +29,7 @@ export function Terminal({ id }: TerminalProps) {
 
   const { isRunning } = usePty({ id });
   const isRunningRef = useRef(isRunning);
+
   useEffect(() => {
     isRunningRef.current = isRunning;
   }, [isRunning]);
@@ -125,7 +126,11 @@ export function Terminal({ id }: TerminalProps) {
       style={{ width: "100%", height: "100%" }}
       className="rounded-pfx-s border border-pfxd-card-border bg-black p-pfx-s"
     >
-      <div style={{ width: "100%", height: "100%" }} ref={ref} />
+      <div
+        style={{ width: "100%", height: "100%" }}
+        className={isRunning ? "" : "[&_.xterm-cursor]:hidden!"}
+        ref={ref}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Hiding it via CSS is a bit hackish, unfortunately we can't modify xterm-react options at runtime...