### PR TITLE
fix: Hide horizontal scrollbars

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   </head>
 
   <body
-    class="bg-pfxgsl-50 text-pfxl-text dark:bg-pfxgsd-800 dark:text-pfxd-text"
+    class="overflow-x-hidden bg-pfxgsl-50 text-pfxl-text dark:bg-pfxgsd-800 dark:text-pfxd-text"
   >
     <div id="app"></div>
     <script type="module" src="/src/main.tsx"></script>


### PR DESCRIPTION
A bit hackish, but gets the job done. 

The `-50vw+50%` trick for the sticky preferences group headers can request additional horizontal space, as `vw` may reserve width for the vertical scrollbar (which also explains why the horizontal scrollbar is only visible together with the vertical scrollbar). 

https://github.com/prefix-dev/pixi-gui/blob/57823daf431a269c1ec56405d77d10a57d9b3fa6/src/components/common/preferencesGroup.tsx#L75
