### PR TITLE
chore(ci): wait 14 days before automerging dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "enabledManagers": ["github-actions", "pixi", "cargo", "npm"],
   "commitMessagePrefix": "chore(ci):",
   "automerge": true,
+  "minimumReleaseAge": "14 days",
   "packageRules": [
     {
       "groupName": "GitHub Actions",


### PR DESCRIPTION
Add minimumReleaseAge of 14 days to Renovate config. This gives upstream registries time to detect and pull malicious packages before they are automerged, improving supply chain security.