### PR TITLE
fix: Update npm and cargo dependencies together (renovate)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,12 +16,8 @@
       "matchManagers": ["pixi"]
     },
     {
-      "groupName": "Cargo",
-      "matchManagers": ["cargo"]
-    },
-    {
-      "groupName": "Npm",
-      "matchManagers": ["npm"]
+      "groupName": "Tauri Dependencies",
+      "matchManagers": ["cargo", "npm"]
     }
   ]
 }


### PR DESCRIPTION
We have to update the npm and cargo dependencies together, to avoid mismatching Tauri packages, like in https://github.com/prefix-dev/pixi-gui/actions/runs/21622492693/job/62314506757?pr=22#step:5:238 (https://github.com/prefix-dev/pixi-gui/pull/22)

```
 │ │        Error Found version mismatched Tauri packages. Make sure the NPM package and Rust crate versions are on the same major/minor releases:
 │ │ tauri (v2.10.1) : @tauri-apps/api (v2.9.1)
 │ │ tauri-plugin-dialog (v2.6.0) : @tauri-apps/plugin-dialog (v2.5.0)

```