### PR TITLE
fix: Ensure that task dialog buttons are always visible

### DIFF
--- a/src/components/pixi/tasks/taskDialog.tsx
+++ b/src/components/pixi/tasks/taskDialog.tsx
@@ -330,8 +330,8 @@ export function TaskDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto">
-        <form onSubmit={handleSubmit}>
+      <DialogContent className="max-h-[90vh] flex flex-col">
+        <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
           <DialogHeader>
             <DialogTitle>
               {isEditMode ? "Edit Task" : "Add New Task"}
@@ -343,7 +343,8 @@ export function TaskDialog({
             </DialogDescription>
           </DialogHeader>
 
-          <PreferencesGroup nested>
+          <div className="overflow-y-auto flex-1">
+            <PreferencesGroup nested>
             {/* Name */}
             <Input
               label="Name"
@@ -619,7 +620,8 @@ export function TaskDialog({
             {submitError && (
               <div className="text-destructive text">{submitError}</div>
             )}
-          </PreferencesGroup>
+            </PreferencesGroup>
+          </div>
 
           <DialogFooter>
             {isEditMode && (


### PR DESCRIPTION
Before

<img width="566" height="744" alt="image" src="https://github.com/user-attachments/assets/b4aa5990-038f-45c8-b14b-25c81141660e" />

After

<img width="567" height="740" alt="image" src="https://github.com/user-attachments/assets/ebb9e856-6f8d-45e5-a84a-fedba3eb6c19" />
