### PR TITLE
Build package with strict environment isolation

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,51 +12,66 @@ source:
 build:
   number: 0
   script:
-    - if: osx
-      then:
-        # WebKit framework linking for macOS, see https://crates.io/crates/wry/0.37.0
-        - export RUSTFLAGS="-l framework=WebKit"
-    - if: unix
-      then:
-        - export RUSTC_WRAPPER=sccache
-        - unset CI
-        - TARGET=${TARGET:-$(rustc -vV | grep "host:" | awk '{print $2}')}
-        - export CARGO_TARGET_DIR=${{ SRC_DIR }}/../../target-cache
-        - pnpm install
-        - pnpm run tauri build --no-bundle
-        - mkdir -p ${{ PREFIX }}/bin
-        - install -m0755 "$CARGO_TARGET_DIR/$TARGET/release/pixi-gui" "${{ PREFIX }}/bin"
-        - cd ${{ SRC_DIR }}/src-tauri && cargo-bundle-licenses --format yaml --output ../THIRDPARTY.yml
+    # The build runs under rattler-build's default strict environment
+    # isolation, which scrubs the host environment. Forward the variables the
+    # sccache GitHub Actions cache backend needs so caching keeps working.
+    env:
+      SCCACHE_GHA_ENABLED: "${{ env.get('SCCACHE_GHA_ENABLED', default='') }}"
+      ACTIONS_CACHE_SERVICE_V2: "${{ env.get('ACTIONS_CACHE_SERVICE_V2', default='') }}"
+      ACTIONS_RESULTS_URL: "${{ env.get('ACTIONS_RESULTS_URL', default='') }}"
+    secrets:
+      - ACTIONS_RUNTIME_TOKEN
+    content:
+      - if: osx
+        then:
+          # WebKit framework linking for macOS, see https://crates.io/crates/wry/0.37.0
+          - export RUSTFLAGS="-l framework=WebKit"
+      - if: unix
+        then:
+          - export RUSTC_WRAPPER=sccache
+          - unset CI
+          - TARGET=${TARGET:-$(rustc -vV | grep "host:" | awk '{print $2}')}
+          - export CARGO_TARGET_DIR=${{ SRC_DIR }}/../../target-cache
+          - pnpm install
+          - pnpm run tauri build --no-bundle
+          - mkdir -p ${{ PREFIX }}/bin
+          - install -m0755 "$CARGO_TARGET_DIR/$TARGET/release/pixi-gui" "${{ PREFIX }}/bin"
+          - cd ${{ SRC_DIR }}/src-tauri && cargo-bundle-licenses --format yaml --output ../THIRDPARTY.yml
 
-        # menuinst
-        - mkdir -p "${{ PREFIX }}/Menu"
-        - if: osx
-          then:
-            - sed "s/__PKG_VERSION__/${PKG_VERSION}/g" "${{ RECIPE_DIR }}/menu.json" > "${{ PREFIX }}/Menu/${{ PKG_NAME }}_menu.json"
-            - install -m0644 "${{ SRC_DIR }}/src-tauri/icons/icon.icns" "${{ PREFIX }}/Menu/icon.icns"
-        - if: linux
-          then:
-            - install -m0644 "${{ RECIPE_DIR }}/menu.json" "${{ PREFIX }}/Menu/${{ PKG_NAME }}_menu.json"
-            - install -m0644 "${{ SRC_DIR }}/src-tauri/icons/icon.png" "${{ PREFIX }}/Menu/icon.png"
-    - if: win
-      then:
-        # Required to fix "path too long" issues
-        - if not "%GITHUB_ACTIONS%"=="" if not exist C:\\cargo-home mkdir C:\\cargo-home
-        - if not "%GITHUB_ACTIONS%"=="" set CARGO_HOME=C:\\cargo-home
+          # menuinst
+          - mkdir -p "${{ PREFIX }}/Menu"
+          - if: osx
+            then:
+              - sed "s/__PKG_VERSION__/${PKG_VERSION}/g" "${{ RECIPE_DIR }}/menu.json" > "${{ PREFIX }}/Menu/${{ PKG_NAME }}_menu.json"
+              - install -m0644 "${{ SRC_DIR }}/src-tauri/icons/icon.icns" "${{ PREFIX }}/Menu/icon.icns"
+          - if: linux
+            then:
+              - install -m0644 "${{ RECIPE_DIR }}/menu.json" "${{ PREFIX }}/Menu/${{ PKG_NAME }}_menu.json"
+              - install -m0644 "${{ SRC_DIR }}/src-tauri/icons/icon.png" "${{ PREFIX }}/Menu/icon.png"
+      - if: win
+        then:
+          # Required to fix "path too long" issues on CI. GITHUB_ACTIONS is read
+          # at recipe render time, so this applies under the default strict
+          # environment isolation where the variable is not forwarded to the
+          # build script.
+          - if: env.get("GITHUB_ACTIONS", default="")
+            then:
+              - if not exist C:\\cargo-home mkdir C:\\cargo-home
+              - set CARGO_HOME=C:\\cargo-home
 
-        - set RUSTC_WRAPPER=sccache
-        - set CI=
-        - set CARGO_TARGET_DIR=%SRC_DIR%\..\..\target-cache
-        - cmd /c "pnpm install"
-        - cmd /c "pnpm run tauri build --no-bundle"
-        - cmd /c "if not exist %PREFIX%\bin\ mkdir %PREFIX%\bin\"
-        - copy /Y %CARGO_TARGET_DIR%\release\pixi-gui.exe %PREFIX%\bin
-        - cd %SRC_DIR%\src-tauri && cargo-bundle-licenses --format yaml --output ../THIRDPARTY.yml
+          - set RUSTC_WRAPPER=sccache
+          - set CI=
+          - set CARGO_TARGET_DIR=%SRC_DIR%\..\..\target-cache
+          - cmd /c "pnpm install"
+          - cmd /c "pnpm run tauri build --no-bundle"
+          - cmd /c "if not exist %PREFIX%\bin\ mkdir %PREFIX%\bin\"
+          - copy /Y %CARGO_TARGET_DIR%\release\pixi-gui.exe %PREFIX%\bin
+          - cd %SRC_DIR%\src-tauri && cargo-bundle-licenses --format yaml --output ../THIRDPARTY.yml
 
-        # menuinst
-        - mkdir "%PREFIX%\Menu"
-        - copy /Y "%RECIPE_DIR%\menu.json" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
-        - copy /Y "%SRC_DIR%\src-tauri\icons\icon.ico" "%PREFIX%\Menu\icon.ico"
+          # menuinst
+          - mkdir "%PREFIX%\Menu"
+          - copy /Y "%RECIPE_DIR%\menu.json" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
+          - copy /Y "%SRC_DIR%\src-tauri\icons\icon.ico" "%PREFIX%\Menu\icon.ico"
 
 requirements:
   build:

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -48,8 +48,6 @@ def build() -> None:
             "build",
             "--recipe",
             "recipe/recipe.yaml",
-            "--env-isolation",
-            "none",
             "--channel",
             "https://prefix.dev/conda-forge",
         ],


### PR DESCRIPTION
Drop --env-isolation none from the rattler-build invocation. That mode inherits the host environment verbatim and does not put build_env on PATH, so rustc, pnpm and the other build tools were not found and every build job failed.

Under the default strict isolation the host environment is scrubbed, so forward the variables the build script still needs:

- The sccache GitHub Actions cache backend reads SCCACHE_GHA_ENABLED, ACTIONS_CACHE_SERVICE_V2, ACTIONS_RESULTS_URL and ACTIONS_RUNTIME_TOKEN. Pass the first three through script.env and the token through script.secrets so it stays masked in logs.
- GITHUB_ACTIONS gated the short CARGO_HOME path that works around Windows MAX_PATH issues. Read it at recipe render time instead, which works regardless of build script isolation.