### PR TITLE
fix: fallback to empty string when pkg.version is null

### DIFF
--- a/src/components/pixi/inspect/columns.ts
+++ b/src/components/pixi/inspect/columns.ts
@@ -63,7 +63,7 @@ export const DEFAULT_VISIBLE_COLUMNS = new Set<ColumnKey>([
 export function getColumnValue(pkg: Package, key: ColumnKey): string {
   switch (key) {
     case "version":
-      return pkg.version;
+      return pkg.version ?? "";
     case "requested-spec":
       return pkg.requested_spec ?? "";
     case "build":


### PR DESCRIPTION
This solves #126 

I believe the cause for the issue was that it was thought that a version of a package can't be null. 
But the pixi.toml of https://github.com/data-apis/array-api-extra put `array-api-extra` (itself) as a dependency in:
```
[dev]
# this pulls in array-api-extra's host and run dependencies
array-api-extra.path = "."

[dependencies]
array-api-extra.path = "."
```

This result in null version for array-api-extra itself.  
The location of the crash was in `isUrl` function (called from packageRow.tsx line 81) because it got a null object instead of a string.  
Indeed, getColumnValue assumed that pkg.version can't be null.  
I believe the fix is to not assume that pkg.version can't be null.  

Here's the app on `array-api-extra` after my change:
<img width="923" height="716" alt="successful_inspect" src="https://github.com/user-attachments/assets/970505a5-3765-474a-bece-a6fb0671a6e7" />
