### PR TITLE
docs: Remove base channel to avoid CEP-42 warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For more information checkout the Pixi GUI [announcement blog post at prefix.dev
 Pixi GUI is available for Windows, macOS (Intel + Apple Silicon) and Linux. Install from our [pixi-gui prefix.dev channel](https://prefix.dev/channels/pixi-gui/packages/pixi-gui):
 
 ```shell
-pixi global install pixi-gui --channel https://prefix.dev/pixi-gui --channel https://prefix.dev/conda-forge
+pixi global install pixi-gui --channel https://prefix.dev/pixi-gui
 ```
 
 Alternatively you can install Pixi GUI from source:


### PR DESCRIPTION
* Modern Pixi releases will emit a CEP-42 warning if an overrides channel is provided before (and so at a higher priority) than its base channel. To avoid this, remove https://prefix.dev/conda-forge (the base channel for https://prefix.dev/pixi-gui) in the pixi-gui install instructions.
   - c.f. https://github.com/conda/ceps/blob/main/cep-0042.md
* Resolves https://github.com/prefix-dev/pixi-gui/issues/134