### PR TITLE
fix(search): remove duplicate packages with the same name

### DIFF
--- a/src-tauri/src/pixi/workspace/search.rs
+++ b/src-tauri/src/pixi/workspace/search.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 use crate::{
     error::Error,
@@ -41,14 +41,22 @@ pub async fn search_wildcard<R: Runtime>(
     )
     .into_diagnostic()?;
 
-    Ok(Some(
-        ctx.search(
+    let packages = ctx
+        .search(
             match_spec,
             channels,
             vec![Platform::current(), Platform::NoArch],
         )
-        .await?,
-    ))
+        .await?;
+
+    let mut seen_packages = HashSet::new();
+
+    let deduplicated_packages: Vec<RepoDataRecord> = packages
+        .into_iter()
+        .filter(|record| seen_packages.insert(record.package_record.name.clone()))
+        .collect();
+
+    Ok(Some(deduplicated_packages))
 }
 
 #[tauri::command]

--- a/src/components/pixi/manifest/condaDependencyDialog.tsx
+++ b/src/components/pixi/manifest/condaDependencyDialog.tsx
@@ -127,7 +127,7 @@ export function CondaDependencyDialog({
       setIsSearching(true);
 
       try {
-        const searchTerm = `*${packageSearch.trim()}*`;
+        const searchTerm = `${packageSearch.trim()}*`;
         const results = await searchWildcard(workspace.root, searchTerm);
 
         // Only update if this is still the most recent search


### PR DESCRIPTION
Fixes #131 

* Keep only one package per name when searching a conda package
* Remove the first wildcard of the search expression to get more intuitive results when searching for a conda package

<img width="912" height="708" alt="numpy_without_duplicates" src="https://github.com/user-attachments/assets/5f139572-df31-4b4e-82b6-89faf9e2a966" />
<img width="912" height="708" alt="numpy_with_wildcard" src="https://github.com/user-attachments/assets/4c877a7b-73a4-4702-84de-fc9dea178b98" />
<img width="918" height="711" alt="python" src="https://github.com/user-attachments/assets/ed526a73-6062-49ae-99f7-2772cd348518" />
