### PR TITLE
fix: improve requires-pixi error to be clearer

### DIFF
--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1,9 +1,8 @@
 use std::{future::Future, io::IsTerminal, path::PathBuf};
 
-use miette::IntoDiagnostic;
 use pixi_api::{
-    WorkspaceContext,
-    core::{Workspace, WorkspaceLocator, workspace::DiscoveryStart},
+    PIXI_VERSION, WorkspaceContext,
+    core::{Workspace, WorkspaceLocator, WorkspaceLocatorError, workspace::DiscoveryStart},
 };
 use strip_ansi_escapes::strip;
 use tauri::{
@@ -28,13 +27,21 @@ where
 }
 
 pub fn workspace(workspace: PathBuf) -> Result<Workspace, Error> {
-    let workspace = WorkspaceLocator::for_cli()
+    let workspace_result = WorkspaceLocator::for_cli()
         .with_consider_environment(false)
         .with_search_start(DiscoveryStart::SearchRoot(workspace))
-        .locate()
-        .into_diagnostic()?;
+        .locate();
 
-    Ok(workspace)
+    workspace_result.map_err(|err| match err {
+        WorkspaceLocatorError::PixiVersionMismatch(mismatch) => {
+            let msg = format!(
+                "This workspace requires pixi '{}'.\nBut this version of pixi-gui is built with pixi {}",
+                mismatch.requires_pixi, PIXI_VERSION
+            );
+            miette::miette!(msg).into()
+        }
+        _ => Error(err.into()),
+    })
 }
 
 pub fn workspace_context<R: Runtime>(


### PR DESCRIPTION
Fixes #124

* Intercepts the error when loading the workspace and modifying it in case of PixiVersionMismatch error. 
<img width="430" height="211" alt="updated-pixi-requires-message" src="https://github.com/user-attachments/assets/c0b2f84d-5871-4a8c-b9bb-39b04b876cde" />
