### PR TITLE
feat(packageDialog): added run_exports to the package dialog

### DIFF
--- a/src/components/pixi/inspect/columns.ts
+++ b/src/components/pixi/inspect/columns.ts
@@ -160,5 +160,6 @@ export function createVirtualPackage(name: string, version: string): Package {
     constrains: [],
     depends: [],
     track_features: [],
+    run_exports: null,
   };
 }

--- a/src/components/pixi/inspect/packageDialog.tsx
+++ b/src/components/pixi/inspect/packageDialog.tsx
@@ -135,6 +135,71 @@ export function PackageDialog({
             </PreferencesGroup>
           )}
 
+          {/* Run Exports */}
+          {pkg.run_exports && (
+            <PreferencesGroup title="Run Exports" nested>
+              {/* Noarch */}
+              {pkg.run_exports.noarch && (
+                <div className="flex flex-wrap gap-1">
+                  {[...pkg.run_exports.noarch].sort().map((c) => (
+                    <Badge key={c} icon="package">
+                      <span>noarch:</span>
+                      {c}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+
+              {/* Weak */}
+              {pkg.run_exports.weak && (
+                <div className="flex flex-wrap gap-1">
+                  {[...pkg.run_exports.weak].sort().map((c) => (
+                    <Badge key={c} icon="package">
+                      <span>weak:</span>
+                      {c}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+
+              {/* Strong */}
+              {pkg.run_exports.strong && (
+                <div className="flex flex-wrap gap-1">
+                  {[...pkg.run_exports.strong].sort().map((c) => (
+                    <Badge key={c} icon="package">
+                      <span>strong:</span>
+                      {c}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+
+              {/* Weak Constraints */}
+              {pkg.run_exports.weak_constrains && (
+                <div className="flex flex-wrap gap-1">
+                  {[...pkg.run_exports.weak_constrains].sort().map((c) => (
+                    <Badge key={c} icon="package">
+                      <span>weak constraints:</span>
+                      {c}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+
+              {/* Strong Constraints*/}
+              {pkg.run_exports.strong_constrains && (
+                <div className="flex flex-wrap gap-1">
+                  {[...pkg.run_exports.strong_constrains].sort().map((c) => (
+                    <Badge key={c} icon="package">
+                      <span>strong constraints:</span>
+                      {c}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </PreferencesGroup>
+          )}
+
           {/* Required By */}
           {revDepNames.length > 0 && (
             <PreferencesGroup title="Required by" nested>

--- a/src/lib/pixi/workspace/list.ts
+++ b/src/lib/pixi/workspace/list.ts
@@ -4,6 +4,13 @@ import type { LockFileUsage } from "@/lib/pixi/workspace/reinstall";
 
 export type PackageKind = "conda" | "pypi";
 
+export interface RunExportsJson {
+  weak?: string[];
+  strong?: string[];
+  noarch?: string[];
+  weak_constrains?: string[];
+  strong_constrains?: string[];
+}
 export interface Package {
   name: string;
   version: string;
@@ -29,6 +36,7 @@ export interface Package {
   constrains: string[];
   depends: string[];
   track_features: string[];
+  run_exports: RunExportsJson | null;
 }
 
 export interface ListPackagesOptions {


### PR DESCRIPTION
Fixes #117 

Add run_exports to the package dialog.  
Requires (https://github.com/prefix-dev/pixi/pull/6676) to be merged and a new version of pixi to be published.  

<details>
<summary>I've built a dummy package to check all types of run_exports:</summary>

```
context:
  name: libcompute-core
  version: "4.2.0"

package:
  name: ${{ name }}
  version: ${{ version }}

source:
  # Using an empty path since we aren't compiling actual source code
  path: .

build:
  number: 0
  # A dummy build command that just outputs text
  script: echo "Building core runtime framework..."
  
requirements:
  build:
    # A lightweight requirement so the build phase triggers
    - bzip2

  run_exports:
      weak:
        - ${{ pin_subpackage(name, upper_bound='x') }}
      strong:
        - ${{ pin_subpackage(name, upper_bound='x.x') }}
      noarch:
        - libcompute-noarch-helper >=4.2.0,<5.0a0
      weak_constraints:
        - compute-tools >=4.2.0,<5.0a0
      strong_constraints:
        - nvidia-driver >=550.0.0
```
</returns>
</details>

<img width="907" height="703" alt="run_exports_success" src="https://github.com/user-attachments/assets/ca3c96f9-70ab-44d3-95c1-ec3fe1920714" />

Another example on python and another package which don't have run_exports:
<img width="908" height="708" alt="run_exports_on_python" src="https://github.com/user-attachments/assets/5ba3b4de-1529-4f39-9bad-bdeffc086220" />
<img width="916" height="706" alt="no_run_exports" src="https://github.com/user-attachments/assets/13852be2-bfe1-4fc5-9f41-f1ff94ea1a4e" />


